### PR TITLE
ci: add diff check before creating automatic PR

### DIFF
--- a/.github/workflows/automatic_pr.yml
+++ b/.github/workflows/automatic_pr.yml
@@ -25,7 +25,7 @@ jobs:
           echo "DIFF_COUNT=$DIFF" >> $GITHUB_ENV
           echo "Number of different commits: $DIFF"
           
-      - name: Crear Pull Request
+      - name: Create Pull Request
         if: env.DIFF_COUNT != '0'
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/automatic_pr.yml
+++ b/.github/workflows/automatic_pr.yml
@@ -23,7 +23,7 @@ jobs:
           git fetch origin develop main
           DIFF=$(git rev-list --count main..develop)
           echo "DIFF_COUNT=$DIFF" >> $GITHUB_ENV
-          echo "Número de commits diferentes: $DIFF"
+          echo "Number of different commits: $DIFF"
           
       - name: Crear Pull Request
         if: env.DIFF_COUNT != '0'

--- a/.github/workflows/automatic_pr.yml
+++ b/.github/workflows/automatic_pr.yml
@@ -12,7 +12,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          
+      - name: Check for differences
+        id: check_diff
+        run: |
+          git fetch origin develop main
+          DIFF=$(git rev-list --count main..develop)
+          echo "DIFF_COUNT=$DIFF" >> $GITHUB_ENV
+          echo "Número de commits diferentes: $DIFF"
+          
       - name: Crear Pull Request
+        if: env.DIFF_COUNT != '0'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
@@ -51,3 +65,7 @@ jobs:
             } else {
               console.log('🔄 Ya existe una pull request abierta de develop a main.');
             }
+      
+      - name: No changes found
+        if: env.DIFF_COUNT == '0'
+        run: echo "No hay cambios entre develop y main. No se creará un PR."

--- a/.github/workflows/automatic_pr.yml
+++ b/.github/workflows/automatic_pr.yml
@@ -68,4 +68,4 @@ jobs:
       
       - name: No changes found
         if: env.DIFF_COUNT == '0'
-        run: echo "No hay cambios entre develop y main. No se creará un PR."
+        run: echo "No changes between develop and main. No PR will be created."

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -32,6 +32,7 @@ jobs:
       DATABASE_PASSWORD: S3cur3P@ssw0rd2024
       DATABASE_HOST: localhost
       DATABASE_PORT: 5432
+      DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
This pull request updates the `.github/workflows/automatic_pr.yml` file to improve the automation of pull request creation by adding a check for differences between the `develop` and `main` branches. It ensures that a pull request is only created if there are actual changes.

Enhancements to pull request automation:

* Added a step to check for differences between the `develop` and `main` branches using the `git rev-list` command. The number of differing commits is stored in the `DIFF_COUNT` environment variable.
* Modified the pull request creation step to only execute if `DIFF_COUNT` is not equal to zero, ensuring pull requests are only created when changes exist.
* Added a new step to log a message when no changes are found between `develop` and `main`, preventing unnecessary pull request creation.