### PR TITLE
fix: dynamically import BlogPostClient to fix 500 error on netlify

### DIFF
--- a/frontend/src/app/[locale]/blog/[slug]/page.tsx
+++ b/frontend/src/app/[locale]/blog/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import { client } from '@/lib/sanity';
 import { postBySlug } from '@/lib/queries';
 import { Metadata } from 'next';
-import BlogPostClient from '@/components/blog/blog-post-client';
 
 export async function generateStaticParams() {
   const slugs: string[] = await client.fetch(
@@ -34,5 +33,9 @@ export default async function Page({ params }: { params: Promise<{ slug: string 
   const { slug } = await params;
   const p = await client.fetch(postBySlug, { slug }, { next: { tags: ['blog', `post:${slug}`] } });
   if (!p || p.isPrivate) return null;
+
+  // Dynamically import the client component at render time so the server
+  // component doesn't import any client-only modules at module scope.
+  const { default: BlogPostClient } = await import('@/components/blog/blog-post-client');
   return <BlogPostClient post={p} />;
 }

--- a/frontend/src/app/[locale]/blog/page.tsx
+++ b/frontend/src/app/[locale]/blog/page.tsx
@@ -1,11 +1,11 @@
 import { client } from '@/lib/sanity';
 import { listPosts } from '@/lib/queries';
-import BlogClient from '@/components/blog/blog-client';
 
 export const revalidate = 300;
 export const dynamic = 'force-static';
 
 export default async function BlogIndex() {
   const posts = await client.fetch(listPosts, {}, { next: { tags: ['blog'] } });
+  const { default: BlogClient } = await import('@/components/blog/blog-client');
   return <BlogClient posts={posts} />;
 }

--- a/frontend/src/sanity/env.ts
+++ b/frontend/src/sanity/env.ts
@@ -2,7 +2,7 @@ export const apiVersion =
   process.env.NEXT_PUBLIC_SANITY_API_VERSION || '2025-09-05'
 
 export const dataset = assertValue(
-  process.env.NEXT_PUBLIC_SANITY_DATASET,
+  process.env.NEXT_PUBLIC_SANITY_DATASET || 'production',
   'Missing environment variable: NEXT_PUBLIC_SANITY_DATASET'
 )
 


### PR DESCRIPTION
This pull request improves how client-only components are imported in the blog pages and makes the Sanity dataset configuration more robust. The most important changes include switching to dynamic imports for client components in blog routes and providing a default value for the Sanity dataset environment variable.

**Client Component Imports**

* Changed both the blog index (`page.tsx`) and individual post (`[slug]/page.tsx`) routes to dynamically import their respective client-only components (`BlogClient` and `BlogPostClient`) at render time. This prevents server components from importing client-only modules at module scope, which improves compatibility and may reduce build issues. ([frontend/src/app/[locale]/blog/page.tsxL3-R9](diffhunk://#diff-5359e2f50eb257cc504e2a53e29cc20215eb8148aea9244d7bd466d7118ab98fL3-R9), [frontend/src/app/[locale]/blog/[slug]/page.tsxL4](diffhunk://#diff-422631c665cb09cf88e6ea18b590eedc149f23a5adf3ffaace657e121ac31aacL4), [frontend/src/app/[locale]/blog/[slug]/page.tsxR36-R39](diffhunk://#diff-422631c665cb09cf88e6ea18b590eedc149f23a5adf3ffaace657e121ac31aacR36-R39))

**Configuration Robustness**

* Updated the Sanity dataset configuration in `sanity/env.ts` to use `'production'` as a default if `NEXT_PUBLIC_SANITY_DATASET` is not set, making local development and deployment more reliable.