### PR TITLE
fix: force dinamic load on blog post pages

### DIFF
--- a/backend/debug_router_urls.py
+++ b/backend/debug_router_urls.py
@@ -1,8 +1,0 @@
-from rest_framework.routers import DefaultRouter
-from courses.views import CourseViewSet
-
-router = DefaultRouter()
-router.register(r'courses', CourseViewSet)
-
-for url in router.urls:
-    print(url)

--- a/frontend/src/app/[locale]/blog/[slug]/page.tsx
+++ b/frontend/src/app/[locale]/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { client } from '@/lib/sanity';
 import { postBySlug } from '@/lib/queries';
 import { Metadata } from 'next';
+export const dynamic = 'force-dynamic';
 
 export async function generateStaticParams() {
   const slugs: string[] = await client.fetch(


### PR DESCRIPTION
This pull request contains minor updates to both the backend and frontend codebases. The backend debug script has been removed, and a configuration change was made to the frontend blog page to enforce dynamic rendering.

Backend cleanup:

* Removed the temporary debug script from `backend/debug_router_urls.py`, which previously printed registered router URLs for the `CourseViewSet`.

Frontend configuration:

* Added `export const dynamic = 'force-dynamic';` to `frontend/src/app/[locale]/blog/[slug]/page.tsx` to ensure the blog detail page is always rendered dynamically. ([frontend/src/app/[locale]/blog/[slug]/page.tsxR4](diffhunk://#diff-422631c665cb09cf88e6ea18b590eedc149f23a5adf3ffaace657e121ac31aacR4))